### PR TITLE
Add formatNumber edge case tests

### DIFF
--- a/src/app/components/results/results.component.spec.ts
+++ b/src/app/components/results/results.component.spec.ts
@@ -76,10 +76,18 @@ describe('ResultsComponent', () => {
       totalModelsKilled: 0,
       profileResults: []
     };
-    
+
     component.totalResults = emptyResults;
     fixture.detectChanges();
-    
+
     expect(component.totalResults.profileResults.length).toBe(0);
+  });
+
+  it('should format NaN and Infinity as 0', () => {
+    const resultNaN = component.formatNumber(NaN);
+    const resultInfinity = component.formatNumber(Infinity);
+
+    expect(resultNaN).toBe(0);
+    expect(resultInfinity).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- test formatNumber with NaN and Infinity in ResultsComponent

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7ae663483288dc20a73747b9773