### PR TITLE
Fix WCAG contrast on Ork theme

### DIFF
--- a/src/app/themes.scss
+++ b/src/app/themes.scss
@@ -61,7 +61,8 @@ body {
 
 .theme-ork-rust {
   --color-primary-text: #d1c7b7; // Dirty, off-white
-  --color-secondary-text: #a39887;
+  // Adjusted for WCAG 2.2 AA contrast compliance
+  --color-secondary-text: #b6aea0;
   --color-background-main: #4a3b2a; // Rusty brown background
   --color-background-panel: rgba(60, 45, 30, 0.92); // Dark, rusty metal panel
   --color-border-panel: #8c5a2b; // Darker rust border
@@ -94,7 +95,7 @@ body {
   --color-protocol-card-bg: rgba(60, 45, 30, 0.8);
   --color-protocol-card-border: #8c5a2b;
   --color-protocol-card-title: #d1bfa0;
-  --color-protocol-card-description: #a39887;
+  --color-protocol-card-description: #b6aea0;
 }
 
 .theme-necrontyr-green {


### PR DESCRIPTION
## Summary
- update ork-rust secondary text color to meet WCAG 2.2 AA
- update matching protocol card description color

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9f8541c8328a528c1d060c297ae