### PR TITLE
Enable lazy loading for profile routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,7 +1,26 @@
 import { Routes } from '@angular/router';
-import { CalculatorComponent } from './components/calculator/calculator.component';
 
 export const routes: Routes = [
-    { path: '', redirectTo: '/calculator', pathMatch: 'full' },
-    { path: 'calculator', component: CalculatorComponent }
+  { path: '', redirectTo: '/calculator', pathMatch: 'full' },
+  {
+    path: 'calculator',
+    loadComponent: () =>
+      import('./components/calculator/calculator.component').then(
+        (m) => m.CalculatorComponent
+      ),
+  },
+  {
+    path: 'attacker-profile',
+    loadComponent: () =>
+      import('./components/attacker-profile/attacker-profile.component').then(
+        (m) => m.AttackerProfileComponent
+      ),
+  },
+  {
+    path: 'defender-profile',
+    loadComponent: () =>
+      import('./components/defender-profile/defender-profile.component').then(
+        (m) => m.DefenderProfileComponent
+      ),
+  },
 ];


### PR DESCRIPTION
## Summary
- configure lazy-loaded routes for attacker and defender profiles using `loadComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9e9c91083289575a6ec368d8369