### PR TITLE
Apply 4px spacing grid

### DIFF
--- a/src/app/styles/utilities.scss
+++ b/src/app/styles/utilities.scss
@@ -176,8 +176,8 @@
 .opacity-100 { opacity: 1 !important; }
 
 /* Transform utilitarios */
-.translate-y-1 { transform: translateY(-1px) !important; }
-.translate-y-2 { transform: translateY(-2px) !important; }
+.translate-y-1 { transform: translateY(-4px) !important; }
+.translate-y-2 { transform: translateY(-8px) !important; }
 .scale-105 { transform: scale(1.05) !important; }
 .scale-110 { transform: scale(1.1) !important; }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1199,13 +1199,14 @@ body.light-theme {
 @media (max-width: 768px) {
     // Mejorar espaciado en móvil
     :root {
-        --spacing-xs: 0.375rem;    // 6px
-        --spacing-sm: 0.75rem;     // 12px
-        --spacing-md: 1rem;        // 16px
-        --spacing-lg: 1.25rem;     // 20px
-        --spacing-xl: 1.5rem;      // 24px
-        --spacing-xxl: 2rem;       // 32px
-        --spacing-xxxl: 2.5rem;    // 40px
+        // Ajustado a una grilla de 4px
+        --spacing-xs: 0.25rem;    // 4px
+        --spacing-sm: 0.5rem;     // 8px
+        --spacing-md: 0.75rem;    // 12px
+        --spacing-lg: 1rem;       // 16px
+        --spacing-xl: 1.25rem;    // 20px
+        --spacing-xxl: 1.5rem;    // 24px
+        --spacing-xxxl: 2rem;     // 32px
     }
     
     // Hacer inputs más grandes en móvil


### PR DESCRIPTION
## Summary
- keep spacing variables on a 4px grid
- use 4px increments in mobile overrides
- tweak translate utilities to match 4px increments

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa52dd1c8328beff20e1d7d105ea