### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint --if-present
+      - run: npm run build --if-present
+      - run: npm test --if-present -- --watch=false --browsers=ChromeHeadless


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run npm scripts for lint, build and tests on pull requests

## Testing
- `npm install eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin --save-dev` *(fails: 403 Forbidden)*
- `npm ci` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa4454d08328ae22265bc666c37f