### PR TITLE
Update fonts to San Francisco

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive mathhammer calculator for Warhammer 40,000 designed to help play
 - **Real-time Calculations**: Instant probability calculations as you modify parameters
 - **Multiple Profiles**: Support for multiple attacker and defender profiles
 - **Modern UI**: Clean, responsive Angular Material interface
+- **macOS-inspired Typography**: Uses the San Francisco font with a `-apple-system` fallback for a consistent look across browsers
 
 ## Development
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -20,7 +20,7 @@
 .theme-selector-container .mat-mdc-form-field .mat-mdc-floating-label,
 .theme-selector-container .mat-mdc-form-field .mat-mdc-select-value-text {
   color: var(--color-secondary-text, #c5b8a5) !important; /* Fallback color */
-  font-family: var(--font-sans-condensed, "Roboto Condensed", sans-serif);
+  font-family: var(--font-sans-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif);
 }
 
 .theme-selector-container .mat-mdc-form-field .mat-mdc-select-arrow svg {
@@ -37,7 +37,7 @@ body .mat-mdc-select-panel.theme-selector-dropdown { /* Add a unique class to th
 
 body .mat-mdc-select-panel.theme-selector-dropdown .mat-mdc-option {
   color: var(--color-text-dropdown-item, #e0e0e0) !important;
-  font-family: var(--font-sans-condensed, "Roboto Condensed", sans-serif) !important;
+  font-family: var(--font-sans-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif) !important;
 }
 
 body .mat-mdc-select-panel.theme-selector-dropdown .mat-mdc-option:hover,

--- a/src/app/themes.scss
+++ b/src/app/themes.scss
@@ -1,7 +1,7 @@
 :root {
   --font-gothic: 'Uncial Antiqua', cursive;
   --font-serif-main: 'EB Garamond', serif;
-  --font-sans-condensed: 'Roboto Condensed', sans-serif;
+  --font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 // Default Dark Theme (matches styles.scss initial dark theme if not overridden by a specific theme class)

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body class="mat-typography">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,7 +26,7 @@ $mathhammer-ng-theme: mat.m2-define-dark-theme((
     warn: $mathhammer-ng-warn,
   ),
   typography: mat.m2-define-typography-config(
-    $font-family: '"Roboto", "Helvetica Neue", sans-serif'
+    $font-family: '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
   ),
   density: 0
 ));
@@ -42,7 +42,7 @@ $mathhammer-ng-light-theme: mat.m2-define-light-theme((
     warn: $mathhammer-ng-warn,
   ),
   typography: mat.m2-define-typography-config(
-    $font-family: '"Roboto", "Helvetica Neue", sans-serif'
+    $font-family: '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
   ),
   density: 0
 ));
@@ -219,7 +219,7 @@ $mathhammer-ng-light-theme: mat.m2-define-light-theme((
 html, body { height: 100%; }
 body {
   margin: 0;
-  font-family: var(--font-sans-condensed, \"Roboto\", \"Helvetica Neue\", sans-serif); // Fallback font
+  font-family: var(--font-sans-condensed, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif); // Fallback font
   background-color: var(--color-background-main); // Use CSS variable
   color: var(--color-primary-text); // Use CSS variable
   transition: background-color 0.3s ease, color 0.3s ease; // Smooth theme transition


### PR DESCRIPTION
## Summary
- use San Francisco font with `-apple-system` fallback
- drop Google Roboto font from the app
- document the new typography style in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa07f08c8328b7724f9615745915