### PR TITLE
Add ESLint and Prettier

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  ],
+  env: {
+    browser: true,
+    es2021: true
+  },
+  parserOptions: {
+    project: './tsconfig.json',
+    sourceType: 'module'
+  },
+  ignorePatterns: ['dist/', 'node_modules/']
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ To execute unit tests with the [Karma](https://karma-runner.github.io) test runn
 ng test
 ```
 
+### Linting and formatting
+
+Code quality is enforced with ESLint and Prettier. Check for lint issues with:
+
+```bash
+npm run lint
+```
+
+Automatically fix problems and format all files using:
+
+```bash
+npm run lint:fix
+npm run format
+```
+
 ## Project Structure
 
 - `src/app/components/` - Angular components for UI

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "lint": "eslint . --ext .ts --config .eslintrc.cjs",
+    "lint:fix": "eslint . --ext .ts --config .eslintrc.cjs --fix",
+    "format": "prettier --write \"**/*.{ts,js,json,html,scss,md}\""
   },
   "private": true,
   "dependencies": {
@@ -35,6 +38,12 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.0",
+    "@typescript-eslint/parser": "^6.13.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint config with TypeScript and Prettier rules
- add Prettier configuration and ignore file
- add lint/format scripts in package.json
- document linting and formatting in README

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ESLint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa37401c8328bc34df7236df5802