### PR TITLE
Add macOS‑like shortcuts and focus styles

### DIFF
--- a/src/app/components/calculator/calculator.component.html
+++ b/src/app/components/calculator/calculator.component.html
@@ -9,14 +9,15 @@
         <div class="section-title-group u-display-flex u-align-items-center u-flex-grow-1">
           <h2 class="section-title-font u-margin-none">{{ sectionTitle }}</h2>
         </div>
-        <button 
+        <button
           mat-icon-button
-          type="button" 
-          class="add-profile-inline-button"
+          type="button"
+          class="add-profile-inline-button keyboard-focus-only"
           (click)="addAttackerProfile()"
           [disabled]="attackerProfiles.length >= maxAttackerProfiles"
           matTooltipPosition="before"
-          matTooltip="Añadir nuevo perfil de atacante">
+          matTooltip="Añadir nuevo perfil de atacante (⌘⇧A)"
+          aria-label="Añadir nuevo perfil de atacante">
           <mat-icon>add_circle_outline</mat-icon>
         </button>
       </div>
@@ -37,14 +38,15 @@
         <div class="section-title-group u-display-flex u-align-items-center u-flex-grow-1">
           <h2 class="section-title-font u-margin-none">PERFILES DEL DEFENSOR</h2>
         </div>
-        <button 
+        <button
           mat-icon-button
-          type="button" 
-          class="add-profile-inline-button"
+          type="button"
+          class="add-profile-inline-button keyboard-focus-only"
           (click)="addDefenderProfile()"
           [disabled]="defenderProfiles.length >= maxDefenderProfiles"
           matTooltipPosition="before"
-          matTooltip="Añadir nuevo perfil de defensor">
+          matTooltip="Añadir nuevo perfil de defensor (⌘⇧D)"
+          aria-label="Añadir nuevo perfil de defensor">
           <mat-icon>add_circle_outline</mat-icon>
         </button>
       </div>
@@ -62,13 +64,15 @@
     </section>
 
     <div class="action-buttons-container">
-      <button 
-        type="button" 
-        class="button-cogitator button-calculate"
+      <button
+        type="button"
+        class="button-cogitator button-calculate keyboard-focus-only"
         (click)="calculate()"
         mat-raised-button
         [matRippleColor]="rippleColor"
-        [matRippleAnimation]="rippleAnimation">
+        [matRippleAnimation]="rippleAnimation"
+        matTooltip="Iniciar análisis (⌘Enter)"
+        aria-label="Iniciar análisis">
         INICIAR ANÁLISIS
       </button>
     </div>

--- a/src/app/components/calculator/calculator.component.ts
+++ b/src/app/components/calculator/calculator.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, HostListener } from '@angular/core';
 import { AttackerProfileService } from '../../services/attacker-profile.service';
 import { DefenderProfileService } from '../../services/defender-profile.service';
 import { CalculationService } from '../../services/calculation.service';
@@ -51,6 +51,23 @@ export class CalculatorComponent implements OnInit, OnDestroy {
   rippleAnimation = { enterDuration: 250, exitDuration: 150 };
 
   private ngUnsubscribe = new Subject<void>();
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyboardShortcuts(event: KeyboardEvent): void {
+    if (event.metaKey) {
+      const key = event.key.toLowerCase();
+      if (key === 'a' && event.shiftKey) {
+        event.preventDefault();
+        this.addAttackerProfile();
+      } else if (key === 'd' && event.shiftKey) {
+        event.preventDefault();
+        this.addDefenderProfile();
+      } else if (key === 'enter') {
+        event.preventDefault();
+        this.calculate();
+      }
+    }
+  }
 
   constructor(
     public attackerProfileService: AttackerProfileService,


### PR DESCRIPTION
## Summary
- add macOS-style keyboard shortcuts using HostListener
- show tooltips with shortcut hints
- apply `keyboard-focus-only` class for visible focus states

## Testing
- `npm run lint` *(fails: A config object is using the "parser" key, which is not supported in flat config system)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fffc23b748328ab9946515c2b7b76