### PR TITLE
Add GitHub Pages deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "ng test",
     "lint": "eslint . --ext .ts --config .eslintrc.cjs",
     "lint:fix": "eslint . --ext .ts --config .eslintrc.cjs --fix",
-    "format": "prettier --write \"**/*.{ts,js,json,html,scss,md}\""
+    "format": "prettier --write \"**/*.{ts,js,json,html,scss,md}\"",
+    "deploy": "ng build --configuration production && npx gh-pages -d dist/mathhammer-ng -b gh-pages"
   },
   "private": true,
   "dependencies": {
@@ -44,6 +45,7 @@
     "@typescript-eslint/parser": "^6.13.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "gh-pages": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a `deploy` script for pushing the production build to `gh-pages`
- include `gh-pages` as a dev dependency

## Testing
- `npm run lint` *(fails: parser key not supported)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fff9dcea083289d1140f3b07714da