### PR TITLE
Expand unit test coverage

### DIFF
--- a/src/app/services/attacker-profile.service.spec.ts
+++ b/src/app/services/attacker-profile.service.spec.ts
@@ -1,0 +1,53 @@
+import { AttackerProfileService } from './attacker-profile.service';
+import { DEFAULT_ATTACKER_PROFILE_DATA } from '../models/attacker-profile.model';
+
+describe('AttackerProfileService', () => {
+  let service: AttackerProfileService;
+
+  beforeEach(() => {
+    service = new AttackerProfileService();
+  });
+
+  it('should start with one profile', () => {
+    expect(service.getProfiles().length).toBe(1);
+  });
+
+  it('should add profiles up to the max', () => {
+    for (let i = 0; i < service.getMaxProfiles(); i++) {
+      service.addProfile();
+    }
+    expect(service.getProfiles().length).toBe(service.getMaxProfiles());
+    expect(service.addProfile()).toBeNull();
+  });
+
+  it('should duplicate an existing profile', () => {
+    const original = service.getProfiles()[0];
+    const dup = service.duplicateProfile(original.id);
+    expect(dup).toBeTruthy();
+    expect(service.getProfiles().length).toBe(2);
+    expect(dup?.data).toEqual(original.data);
+  });
+
+  it('should remove a profile when more than one exists', () => {
+    service.addProfile();
+    const id = service.getProfiles()[0].id;
+    const result = service.removeProfile(id);
+    expect(result).toBeTrue();
+    expect(service.getProfiles().length).toBe(1);
+  });
+
+  it('should not remove the last profile', () => {
+    const id = service.getProfiles()[0].id;
+    expect(service.removeProfile(id)).toBeFalse();
+    expect(service.getProfiles().length).toBe(1);
+  });
+
+  it('should reset all profiles to defaults', () => {
+    service.addProfile();
+    service.updateProfile(service.getProfiles()[0].id, { attacks: '20' });
+    service.resetAllProfiles();
+    service.getProfiles().forEach((p) => {
+      expect(p.data).toEqual(DEFAULT_ATTACKER_PROFILE_DATA);
+    });
+  });
+});

--- a/src/app/services/calculation.service.spec.ts
+++ b/src/app/services/calculation.service.spec.ts
@@ -1,0 +1,25 @@
+import { CalculationService } from './calculation.service';
+
+describe('CalculationService', () => {
+  let service: CalculationService;
+
+  beforeEach(() => {
+    service = new CalculationService();
+  });
+
+  it('should interpret simple dice strings', () => {
+    expect(service.interpretDiceValue('D6')).toBe(3.5);
+    expect(service.interpretDiceValue('2D6')).toBe(7);
+    expect(service.interpretDiceValue('D6+1')).toBe(4.5);
+    expect(service.interpretDiceValue('2D6+1')).toBe(8);
+  });
+
+  it('should return 0 for invalid values', () => {
+    expect(service.interpretDiceValue('bad')).toBe(0);
+    expect(service.interpretDiceValue('')).toBe(0);
+  });
+
+  it('should parse fixed numbers', () => {
+    expect(service.interpretDiceValue('5')).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- improve attacker-profile component tests with more edge cases
- rewrite calculator component tests for current logic
- add tests for attacker-profile service
- add tests for calculation service

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fffba6c04832888c85ee3a232c42d