### PR TITLE
Fix package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .ts --config .eslintrc.cjs",
     "lint:fix": "eslint . --ext .ts --config .eslintrc.cjs --fix",
     "format": "prettier --write \"**/*.{ts,js,json,html,scss,md}\"",
-    "deploy": "ng build --configuration production && npx gh-pages -d dist/mathhammer-ng -b gh-pages"
+    "deploy": "ng build --configuration production && npx gh-pages -d dist/mathhammer-ng -b gh-pages",
     "prepare": "husky install"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- fix syntax error in package.json scripts causing npm ci failure

## Testing
- `npm run lint` *(fails: parser unsupported)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68400299d73083288ba84d7cd6fab875