### PR TITLE
Centralize design tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .ts --config .eslintrc.cjs",
     "lint:fix": "eslint . --ext .ts --config .eslintrc.cjs --fix",
     "format": "prettier --write \"**/*.{ts,js,json,html,scss,md}\"",
-    "deploy": "ng build --configuration production && npx gh-pages -d dist/mathhammer-ng -b gh-pages"
+    "deploy": "ng build --configuration production && npx gh-pages -d dist/mathhammer-ng -b gh-pages",
     "prepare": "husky install"
   },
   "private": true,

--- a/src/app/themes.scss
+++ b/src/app/themes.scss
@@ -1,25 +1,6 @@
-:root {
-  --font-gothic: 'Uncial Antiqua', cursive;
-  --font-serif-main: 'EB Garamond', serif;
-  --font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-}
+@use '../styles/design-tokens.scss';
 
-// Default Dark Theme (matches styles.scss initial dark theme if not overridden by a specific theme class)
-body {
-  // These are fallbacks if no specific theme class is applied or for base styling
-  --color-primary-text: #c5c5c5;
-  --color-secondary-text: #9e8a74;
-  --color-background-main: #1a1a1a;
-  --color-background-panel: #2a2a2a;
-  --color-border-panel: #444;
-  --color-input-bg: #333322; // Darker, parchment-like
-  --color-metal-interactive: #5a5a5a;
-  --color-metal-interactive-hover: #7a7a7a;
-  --color-accent-glow: #ff8c00; // Default glow for dark
-  --color-accent-red: #b71c1c;
-  --color-accent-red-dark: #8a0000;
-  --color-accent-green-cogitator: #4CAF50; // A more vibrant green for cogitators
-}
+// Theme specific overrides. The default values are defined in design-tokens.scss
 
 .theme-imperium-dark {
   --color-primary-text: #e0dac5; // Parchment text

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,7 @@ $mat-theme-ignore-duplication-warnings: true; // Keep for now, aim to remove if 
 // END: Configuration
 
 @use '@angular/material' as mat;
+@use './styles/design-tokens.scss' as tokens;
 @use './app/themes.scss' as themes;
 @use './app/styles/utilities.scss' as utilities;
 @use './app/styles/shared-components.scss' as shared;
@@ -190,26 +191,7 @@ $mathhammer-ng-light-theme: mat.m2-define-light-theme((
 
 /* You can add global styles to this file, and also import other style files */
 
-// Sistema de espaciado consistente
-:root {
-  --spacing-xs: 0.25rem;    // 4px
-  --spacing-sm: 0.5rem;     // 8px
-  --spacing-md: 0.75rem;    // 12px
-  --spacing-lg: 1rem;       // 16px
-  --spacing-xl: 1.25rem;    // 20px
-  --spacing-xxl: 1.5rem;    // 24px
-  --spacing-xxxl: 2rem;     // 32px
-  
-  // Border radius consistente
-  --border-radius-sm: 3px;
-  --border-radius-md: 6px;
-  --border-radius-lg: 8px;
-  
-  // Shadows
-  --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-  --shadow-medium: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
-  --shadow-strong: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
-}
+
 
 // Box-sizing global para mejor manejo de padding
 *, *::before, *::after {
@@ -1198,16 +1180,7 @@ body.light-theme {
 /* Responsive mejoras */
 @media (max-width: 768px) {
     // Mejorar espaciado en móvil
-    :root {
-        // Ajustado a una grilla de 4px
-        --spacing-xs: 0.25rem;    // 4px
-        --spacing-sm: 0.5rem;     // 8px
-        --spacing-md: 0.75rem;    // 12px
-        --spacing-lg: 1rem;       // 16px
-        --spacing-xl: 1.25rem;    // 20px
-        --spacing-xxl: 1.5rem;    // 24px
-        --spacing-xxxl: 2rem;     // 32px
-    }
+
     
     // Hacer inputs más grandes en móvil
     .input-field-font, .input-field-text-font {

--- a/src/styles/design-tokens.scss
+++ b/src/styles/design-tokens.scss
@@ -1,0 +1,40 @@
+/* Global design tokens for the application */
+:root {
+  /* Typography */
+  --font-gothic: 'Uncial Antiqua', cursive;
+  --font-serif-main: 'EB Garamond', serif;
+  --font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+  /* Spacing scale */
+  --spacing-xs: 0.25rem;    /* 4px */
+  --spacing-sm: 0.5rem;     /* 8px */
+  --spacing-md: 0.75rem;    /* 12px */
+  --spacing-lg: 1rem;       /* 16px */
+  --spacing-xl: 1.25rem;    /* 20px */
+  --spacing-xxl: 1.5rem;    /* 24px */
+  --spacing-xxxl: 2rem;     /* 32px */
+
+  /* Border radius */
+  --border-radius-sm: 3px;
+  --border-radius-md: 6px;
+  --border-radius-lg: 8px;
+
+  /* Shadows */
+  --shadow-subtle: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  --shadow-medium: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  --shadow-strong: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+
+  /* Default dark theme colors */
+  --color-primary-text: #c5c5c5;
+  --color-secondary-text: #9e8a74;
+  --color-background-main: #1a1a1a;
+  --color-background-panel: #2a2a2a;
+  --color-border-panel: #444;
+  --color-input-bg: #333322; /* Darker, parchment-like */
+  --color-metal-interactive: #5a5a5a;
+  --color-metal-interactive-hover: #7a7a7a;
+  --color-accent-glow: #ff8c00; /* Default glow for dark */
+  --color-accent-red: #b71c1c;
+  --color-accent-red-dark: #8a0000;
+  --color-accent-green-cogitator: #4CAF50; /* Vibrant green for cogitators */
+}


### PR DESCRIPTION
## Summary
- create `design-tokens.scss` with shared CSS variables
- import tokens into global and theme styles
- remove duplicated token definitions
- fix package.json script comma

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684002a437dc83288c868cb27b3802db