### PR TITLE
Fix Angular template errors

### DIFF
--- a/src/app/components/attacker-profile/attacker-profile.component.html
+++ b/src/app/components/attacker-profile/attacker-profile.component.html
@@ -444,7 +444,7 @@
                        'neutral': profileData.shootingModifier?.value === 0,
                        'negative': profileData.shootingModifier?.value === -1
                      }">
-                  {{ profileData.shootingModifier?.value > 0 ? '+' : '' }}{{ profileData.shootingModifier?.value || '0' }}
+                  {{ (profileData.shootingModifier?.value ?? 0) > 0 ? '+' : '' }}{{ profileData.shootingModifier?.value ?? 0 }}
                 </div>
               </mat-card-content>
             </mat-card>            <!-- Torrent Protocol Card -->

--- a/src/app/components/calculator/calculator.component.ts
+++ b/src/app/components/calculator/calculator.component.ts
@@ -12,6 +12,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatRippleModule } from '@angular/material/core';
 import { FormsModule } from '@angular/forms';
 import { AttackerProfileComponent } from '../attacker-profile/attacker-profile.component';
 import { DefenderProfileComponent } from '../defender-profile/defender-profile.component';
@@ -26,9 +27,10 @@ import { Observable } from 'rxjs';
     CommonModule, 
     MatButtonModule, 
     MatIconModule, 
-    MatFormFieldModule, 
-    MatInputModule, 
-    FormsModule, 
+    MatFormFieldModule,
+    MatInputModule,
+    MatRippleModule,
+    FormsModule,
     AttackerProfileComponent, 
     DefenderProfileComponent, 
     ResultsComponent

--- a/src/app/components/protocol-modal/protocol-modal.component.ts
+++ b/src/app/components/protocol-modal/protocol-modal.component.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
+import { MatRippleModule } from '@angular/material/core';
 
 export interface ProtocolModalData {
   title: string;
@@ -38,7 +39,8 @@ export interface ProtocolField {
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatIconModule
+    MatIconModule,
+    MatRippleModule
   ],
   template: `
     <div class="protocol-modal">

--- a/src/app/services/calculation.service.ts
+++ b/src/app/services/calculation.service.ts
@@ -45,8 +45,8 @@ export class CalculationService {
     }
     
     // Formato DX+Y o DX-Y (ej: D6+1)
-    if (diceString.match(/^D\d+[\+\-]\d+$/)) {
-      const match = diceString.match(/D(\d+)([\+\-])(\d+)/);
+    if (diceString.match(/^D\d+[+-]\d+$/)) {
+      const match = diceString.match(/D(\d+)([+-])(\d+)/);
       if (match) {
         const numSides = parseInt(match[1]);
         const operator = match[2];
@@ -57,8 +57,8 @@ export class CalculationService {
     }
     
     // Formato XDXY+Z o XDY-Z (ej: 2D6+1)
-    if (diceString.match(/^\d+D\d+[\+\-]\d+$/)) {
-      const match = diceString.match(/(\d+)D(\d+)([\+\-])(\d+)/);
+    if (diceString.match(/^\d+D\d+[+-]\d+$/)) {
+      const match = diceString.match(/(\d+)D(\d+)([+-])(\d+)/);
       if (match) {
         const numDice = parseInt(match[1]);
         const numSides = parseInt(match[2]);

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -24,7 +24,7 @@ export class ThemeService {
   constructor(
     private rendererFactory: RendererFactory2,
     @Inject(DOCUMENT) private document: Document,
-    @Inject(PLATFORM_ID) private platformId: Object
+    @Inject(PLATFORM_ID) private platformId: object
   ) {
     this.renderer = this.rendererFactory.createRenderer(null, null);
     this.loadTheme();


### PR DESCRIPTION
## Summary
- handle optional modifier display in attacker profile template
- enable ripple customization in calculator and protocol modal
- correct regex patterns for dice strings
- fix type on `platformId`

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npx ng test --watch=false` *(fails: Karma errors)*

------
https://chatgpt.com/codex/tasks/task_e_68400bb216bc832888b0e447c42766c4