### PR TITLE
Add global design token variables

### DIFF
--- a/src/styles/design-tokens.scss
+++ b/src/styles/design-tokens.scss
@@ -1,9 +1,39 @@
 /* Global design tokens for the application */
+
+// ---------------------------------------------------------------------------
+// SCSS variables
+// Define fonts and a minimal color palette that can be reused throughout the
+// stylesheets. These variables are also exported as CSS custom properties under
+// :root so they are available at runtime.
+// ---------------------------------------------------------------------------
+
+// Typography
+$font-gothic: 'Uncial Antiqua', cursive;
+$font-serif-main: 'EB Garamond', serif;
+$font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+// Colors - minimal palette
+$color-primary-text: #c5c5c5;
+$color-secondary-text: #9e8a74;
+$color-background-main: #1a1a1a;
+$color-background-panel: #2a2a2a;
+$color-border-panel: #444;
+$color-input-bg: #333322; // Darker, parchment-like
+$color-metal-interactive: #5a5a5a;
+$color-metal-interactive-hover: #7a7a7a;
+$color-accent-glow: #ff8c00; // Default glow for dark
+$color-accent-red: #b71c1c;
+$color-accent-red-dark: #8a0000;
+$color-accent-green-cogitator: #4CAF50; // Vibrant green for cogitators
+
+// ---------------------------------------------------------------------------
+// CSS Custom Properties
+// ---------------------------------------------------------------------------
 :root {
   /* Typography */
-  --font-gothic: 'Uncial Antiqua', cursive;
-  --font-serif-main: 'EB Garamond', serif;
-  --font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-gothic: #{$font-gothic};
+  --font-serif-main: #{$font-serif-main};
+  --font-sans-condensed: #{$font-sans-condensed};
 
   /* Spacing scale */
   --spacing-xs: 0.25rem;    /* 4px */
@@ -25,16 +55,16 @@
   --shadow-strong: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
 
   /* Default dark theme colors */
-  --color-primary-text: #c5c5c5;
-  --color-secondary-text: #9e8a74;
-  --color-background-main: #1a1a1a;
-  --color-background-panel: #2a2a2a;
-  --color-border-panel: #444;
-  --color-input-bg: #333322; /* Darker, parchment-like */
-  --color-metal-interactive: #5a5a5a;
-  --color-metal-interactive-hover: #7a7a7a;
-  --color-accent-glow: #ff8c00; /* Default glow for dark */
-  --color-accent-red: #b71c1c;
-  --color-accent-red-dark: #8a0000;
-  --color-accent-green-cogitator: #4CAF50; /* Vibrant green for cogitators */
+  --color-primary-text: #{$color-primary-text};
+  --color-secondary-text: #{$color-secondary-text};
+  --color-background-main: #{$color-background-main};
+  --color-background-panel: #{$color-background-panel};
+  --color-border-panel: #{$color-border-panel};
+  --color-input-bg: #{$color-input-bg};
+  --color-metal-interactive: #{$color-metal-interactive};
+  --color-metal-interactive-hover: #{$color-metal-interactive-hover};
+  --color-accent-glow: #{$color-accent-glow};
+  --color-accent-red: #{$color-accent-red};
+  --color-accent-red-dark: #{$color-accent-red-dark};
+  --color-accent-green-cogitator: #{$color-accent-green-cogitator};
 }


### PR DESCRIPTION
## Summary
- define font and color palette variables in `design-tokens.scss`
- expose them as CSS custom properties for runtime usage

## Testing
- `npm test` *(fails: No Chrome binary)*
- `npm run lint` *(fails: many prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840190d86dc8328b6ef2cdf13715c05