### PR TITLE
Update global font stack

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,7 +27,7 @@ $mathhammer-ng-theme: mat.m2-define-dark-theme((
     warn: $mathhammer-ng-warn,
   ),
   typography: mat.m2-define-typography-config(
-    $font-family: '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+    $font-family: '"SF Pro", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
   ),
   density: 0
 ));
@@ -43,7 +43,7 @@ $mathhammer-ng-light-theme: mat.m2-define-light-theme((
     warn: $mathhammer-ng-warn,
   ),
   typography: mat.m2-define-typography-config(
-    $font-family: '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+    $font-family: '"SF Pro", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
   ),
   density: 0
 ));

--- a/src/styles/design-tokens.scss
+++ b/src/styles/design-tokens.scss
@@ -10,7 +10,7 @@
 // Typography
 $font-gothic: 'Uncial Antiqua', cursive;
 $font-serif-main: 'EB Garamond', serif;
-$font-sans-condensed: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+$font-sans-condensed: 'SF Pro', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 
 // Colors - minimal palette
 $color-primary-text: #c5c5c5;


### PR DESCRIPTION
## Summary
- use the `SF Pro` font with fallbacks in design tokens
- apply the new font stack to Angular Material typography

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: parser not supported in flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68402272434c832883a5baf084029ed3