### PR TITLE
Add Imperium light theme variant

### DIFF
--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -18,7 +18,8 @@ export class ThemeService {
     { name: 'Imperium Dark', value: 'theme-imperium-dark' },
     { name: 'Ork Rust', value: 'theme-ork-rust' },
     { name: 'Necrontyr Green', value: 'theme-necrontyr-green' },
-    { name: 'Light Theme', value: 'light-theme' }
+    { name: 'Light Theme', value: 'light-theme' },
+    { name: 'Imperium Light', value: 'theme-imperium-light' }
   ];
 
   constructor(

--- a/src/app/themes.scss
+++ b/src/app/themes.scss
@@ -156,5 +156,44 @@
   --color-protocol-card-description: #555555;
 }
 
+// Imperium Light Theme (alternative light mode)
+.theme-imperium-light {
+  --color-primary-text: #4a3a2b; // Dark parchment text
+  --color-secondary-text: #6b5a44;
+  --color-background-main: #faf7f2; // Warm parchment background
+  --color-background-panel: #f5f0e6;
+  --color-border-panel: #d0c0a0;
+  --color-input-bg: #ffffff;
+  --color-metal-interactive: #c8b37a;
+  --color-metal-interactive-hover: #d8c48a;
+  --color-accent-glow: #ff9900;
+  --color-accent-red: #cc2a2a;
+  --color-accent-red-dark: #b02020;
+  --color-accent-green-cogitator: #4da256;
+  --color-text-header-main: #3a3028;
+  --color-text-title: #5f503f;
+  --color-text-parchment: #4a3a2b;
+  --color-text-screen: #4a3a2b;
+  --color-metal-panel: #f2ece0;
+  --color-metal-panel-border: #d8c5a1;
+  --color-metal-section: #f7f2e6;
+  --color-metal-section-border: #e8dcc7;
+  --color-metal-dark-bg: #eae3d2;
+  --color-accent-blue-cogitator-hover: #708bd2;
+
+  // Dropdown/menu variables
+  --color-background-dropdown: #ffffff;
+  --color-border-dropdown: #d0c0a0;
+  --color-text-dropdown-item: #4a3a2b;
+  --color-text-dropdown-item-hover: #333333;
+  --color-background-dropdown-hover: #f1e9d8;
+
+  // Protocol card variables
+  --color-protocol-card-bg: #ffffff;
+  --color-protocol-card-border: #d0c0a0;
+  --color-protocol-card-title: #5f503f;
+  --color-protocol-card-description: #6b5a44;
+}
+
 // Ensure this file is imported into styles.scss
 // @import 'themes.scss'; // Add this line to your main styles.scss

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -53,8 +53,9 @@ $mathhammer-ng-light-theme: mat.m2-define-light-theme((
 // Apply the base (dark) theme globally.
 @include mat.all-component-themes($mathhammer-ng-theme);
 
-// Apply the light theme when .light-theme class is present.
-.light-theme {
+// Apply the light theme when .light-theme or .theme-imperium-light class is present.
+.light-theme,
+.theme-imperium-light {
   @include mat.all-component-themes($mathhammer-ng-light-theme);
 
   // Your existing light theme CSS variable overrides:
@@ -199,8 +200,9 @@ body {
   transition: background-color 0.3s ease, color 0.3s ease; // Smooth theme transition
 }
 
-// Styles for the light theme (ensure body selector is specific enough if .light-theme is on body)
-.light-theme body, .light-theme { // Ensure .light-theme on body also applies these
+// Styles for the light themes (ensure body selector is specific enough if the theme class is on body)
+.light-theme body, .light-theme,
+.theme-imperium-light body, .theme-imperium-light {
   background-color: var(--color-background-main) !important;
   color: var(--color-primary-text) !important;
 }
@@ -234,7 +236,8 @@ body {
   border: 1px solid var(--color-border-panel); // Use CSS variable
 }
 
-.light-theme .mat-mdc-card {
+.light-theme .mat-mdc-card,
+.theme-imperium-light .mat-mdc-card {
   background-color: var(--color-background-panel); // CSS variable from .light-theme scope
   color: var(--color-primary-text);
   border: 1px solid var(--color-border-panel);
@@ -683,7 +686,7 @@ body {
 
 // Ensure theme-specific overrides for Material components are applied correctly
 // These will apply the variables defined in themes.scss for each theme context
-.theme-imperium-dark, .theme-ork-rust, .theme-necrontyr-green {
+.theme-imperium-dark, .theme-ork-rust, .theme-necrontyr-green, .theme-imperium-light {
     // This block is intentionally left for future theme-specific structural overrides if needed.
     // Most styling is handled by CSS variables.
     // Adding a dummy rule to satisfy the linter for now if it complains about empty rulesets.
@@ -696,12 +699,13 @@ body {
 // The .input-field-font and button styles above are already doing this.
 
 // Final check on body styles for themes
-body.theme-imperium-dark, body.theme-ork-rust, body.theme-necrontyr-green {
+body.theme-imperium-dark, body.theme-ork-rust, body.theme-necrontyr-green, body.theme-imperium-light {
     background-color: var(--color-background-main);
     color: var(--color-primary-text);
 }
 
-body.light-theme {
+body.light-theme,
+body.theme-imperium-light {
     background-color: var(--color-background-main) !important; // Ensure override
     color: var(--color-primary-text) !important; // Ensure override
 }


### PR DESCRIPTION
## Summary
- define `theme-imperium-light` variables in `themes.scss`
- register the new theme in `ThemeService`
- apply light-theme styles to `.theme-imperium-light` in `styles.scss`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ESLint parser not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6840226889f08328ba17e9dc13a26673