### PR TITLE
Refactor header navigation

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,12 +1,17 @@
 <div class="theme-selector-container">
   <mat-form-field appearance="outline">
     <mat-label>Select Theme</mat-label>
-    <mat-select [value]="currentTheme" (selectionChange)="onThemeChange($event.value)">
+    <mat-select
+      [value]="currentTheme"
+      (selectionChange)="onThemeChange($event.value)"
+    >
       <mat-option *ngFor="let theme of availableThemes" [value]="theme.value">
         {{ theme.name }}
       </mat-option>
     </mat-select>
   </mat-form-field>
 </div>
+
+<app-header></app-header>
 
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from './components/header/header.component';
 import { ThemeService } from './services/theme.service';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -8,20 +9,27 @@ import { CommonModule } from '@angular/common';
 @Component({
   selector: 'app-root',
   standalone: true, // Added standalone: true
-  imports: [RouterOutlet, MatSelectModule, MatFormFieldModule, CommonModule],
+  imports: [
+    RouterOutlet,
+    MatSelectModule,
+    MatFormFieldModule,
+    CommonModule,
+    HeaderComponent,
+  ],
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
   title = 'mathhammer-ng';
-  availableThemes: { name: string, value: string }[] = [];
+  availableThemes: { name: string; value: string }[] = [];
   currentTheme: string = '';
 
   constructor(private themeService: ThemeService) {}
 
   ngOnInit(): void {
     this.availableThemes = this.themeService.getAvailableThemes();
-    this.themeService.currentTheme$.subscribe((theme: string) => { // Explicitly type theme
+    this.themeService.currentTheme$.subscribe((theme: string) => {
+      // Explicitly type theme
       this.currentTheme = theme;
     });
   }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,0 +1,9 @@
+<mat-toolbar class="app-header-toolbar" color="primary">
+  <span class="app-title">MathHammer</span>
+  <span class="spacer"></span>
+  <nav>
+    <a mat-button routerLink="/calculator">Calculadora</a>
+    <a mat-button routerLink="/attacker-profile">Atacante</a>
+    <a mat-button routerLink="/defender-profile">Defensor</a>
+  </nav>
+</mat-toolbar>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,0 +1,17 @@
+.app-header-toolbar {
+  display: flex;
+  background-color: var(--color-background-panel, #2a2a2a);
+  color: var(--color-text-header-main, #fff);
+  border-bottom: 1px solid var(--color-border-panel, #444);
+  box-shadow: none;
+  padding: var(--spacing-sm) var(--spacing-lg);
+
+  .spacer {
+    flex: 1 1 auto;
+  }
+
+  a[mat-button] {
+    margin-right: var(--spacing-sm);
+    text-transform: uppercase;
+  }
+}

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [RouterLink, MatToolbarModule, MatButtonModule],
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent {}


### PR DESCRIPTION
## Summary
- add an `app-header` standalone component
- use the new header in AppComponent
- style header with a flat look

## Testing
- `npm run lint` *(fails: A config object is using the "parser" key)*
- `npx ng test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684023300db483289961f4e05a6845d6