### PR TITLE
Add ThemeToggle component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,4 +9,6 @@
   </mat-form-field>
 </div>
 
+<app-theme-toggle></app-theme-toggle>
+
 <router-outlet></router-outlet>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,6 +5,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ThemeToggleComponent } from './components/theme-toggle/theme-toggle.component';
 import { of } from 'rxjs';
 
 // Mock del ThemeService
@@ -25,7 +26,8 @@ describe('AppComponent', () => {
         NoopAnimationsModule,
         MatSelectModule,
         MatFormFieldModule,
-        RouterTestingModule
+        RouterTestingModule,
+        ThemeToggleComponent
       ],
       providers: [
         { provide: ThemeService, useValue: mockThemeService }
@@ -50,6 +52,13 @@ describe('AppComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('mat-select')).toBeTruthy();
     expect(compiled.querySelector('mat-label')?.textContent).toContain('Select Theme');
+  });
+
+  it('should render theme toggle component', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-theme-toggle')).toBeTruthy();
   });
 
   it('should initialize with available themes', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,11 +4,18 @@ import { ThemeService } from './services/theme.service';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { CommonModule } from '@angular/common';
+import { ThemeToggleComponent } from './components/theme-toggle/theme-toggle.component';
 
 @Component({
   selector: 'app-root',
   standalone: true, // Added standalone: true
-  imports: [RouterOutlet, MatSelectModule, MatFormFieldModule, CommonModule],
+  imports: [
+    RouterOutlet,
+    MatSelectModule,
+    MatFormFieldModule,
+    CommonModule,
+    ThemeToggleComponent
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/src/app/components/theme-toggle/theme-toggle.component.html
+++ b/src/app/components/theme-toggle/theme-toggle.component.html
@@ -1,0 +1,6 @@
+<mat-slide-toggle
+  [checked]="isDarkMode"
+  (change)="toggleTheme($event.checked)"
+>
+  Dark Mode
+</mat-slide-toggle>

--- a/src/app/components/theme-toggle/theme-toggle.component.scss
+++ b/src/app/components/theme-toggle/theme-toggle.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-block;
+}

--- a/src/app/components/theme-toggle/theme-toggle.component.spec.ts
+++ b/src/app/components/theme-toggle/theme-toggle.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ThemeToggleComponent } from './theme-toggle.component';
+import { ThemeService } from '../../services/theme.service';
+
+class MockThemeService {
+  theme = 'light-theme';
+  getCurrentTheme() { return this.theme; }
+  setTheme(theme: string) { this.theme = theme; localStorage.setItem('mathhammer-theme', theme); }
+}
+
+describe('ThemeToggleComponent', () => {
+  let component: ThemeToggleComponent;
+  let fixture: ComponentFixture<ThemeToggleComponent>;
+  let service: MockThemeService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ThemeToggleComponent, NoopAnimationsModule],
+      providers: [{ provide: ThemeService, useClass: MockThemeService }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ThemeToggleComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(ThemeService) as unknown as MockThemeService;
+    localStorage.clear();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with light mode', () => {
+    expect(component.isDarkMode).toBeFalse();
+  });
+
+  it('should toggle to dark mode and persist', () => {
+    component.toggleTheme(true);
+    expect(service.theme).toBe('theme-imperium-dark');
+    expect(localStorage.getItem('mathhammer-theme')).toBe('theme-imperium-dark');
+  });
+
+  it('should toggle to light mode and persist', () => {
+    component.toggleTheme(false);
+    expect(service.theme).toBe('light-theme');
+    expect(localStorage.getItem('mathhammer-theme')).toBe('light-theme');
+  });
+});

--- a/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { ThemeService } from '../../services/theme.service';
+
+@Component({
+  selector: 'app-theme-toggle',
+  standalone: true,
+  imports: [CommonModule, MatSlideToggleModule],
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.scss']
+})
+export class ThemeToggleComponent implements OnInit {
+  isDarkMode = false;
+
+  constructor(private themeService: ThemeService) {}
+
+  ngOnInit(): void {
+    this.isDarkMode = this.themeService.getCurrentTheme() !== 'light-theme';
+  }
+
+  toggleTheme(checked: boolean): void {
+    this.isDarkMode = checked;
+    const newTheme = checked ? 'theme-imperium-dark' : 'light-theme';
+    this.themeService.setTheme(newTheme);
+  }
+}


### PR DESCRIPTION
## Summary
- add new ThemeToggle standalone component
- add ThemeToggle to App component template and module
- test ThemeToggle behaviour with mocked localStorage
- update App component tests for ThemeToggle

## Testing
- `npm run lint` *(fails: parser key not supported)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684023721ea4832887ab79c7004fdeed