### PR TITLE
feat: simplify profile card styles

### DIFF
--- a/src/app/components/attacker-profile/attacker-profile.component.html
+++ b/src/app/components/attacker-profile/attacker-profile.component.html
@@ -1,4 +1,4 @@
-<mat-card class="attacker-profile-card" [ngClass]="currentTheme">
+<mat-card class="profile-card" [ngClass]="currentTheme">
   <!-- Toolbar for Profile Actions, Name, and Attacks Display -->
   <mat-toolbar class="attacker-profile-toolbar">
     <!-- Profile Name Display (Clickable to Edit) / Input Field -->

--- a/src/app/components/attacker-profile/attacker-profile.component.scss
+++ b/src/app/components/attacker-profile/attacker-profile.component.scss
@@ -123,7 +123,7 @@
   display: block; // Ensures the component takes up block space
 }
 
-.attacker-profile-card {
+.profile-card {
   @include mat.elevation(2); // Standard Material card elevation
   margin-bottom: 20px; // Space below the card
   transition: box-shadow 0.3s ease-in-out;

--- a/src/app/components/attacker-profile/attacker-profile.component.spec.ts
+++ b/src/app/components/attacker-profile/attacker-profile.component.spec.ts
@@ -69,7 +69,7 @@ describe('AttackerProfileComponent', () => {
 
   it('should render the attacker profile card', () => {
     const compiled = fixture.nativeElement as HTMLElement;
-    const card = compiled.querySelector('.attacker-profile-card') as HTMLElement;
+    const card = compiled.querySelector('.profile-card') as HTMLElement;
     expect(card).toBeTruthy();
   });
 

--- a/src/app/components/defender-profile/defender-profile.component.html
+++ b/src/app/components/defender-profile/defender-profile.component.html
@@ -1,4 +1,4 @@
-<div class="profile-card data-section u-padding-md u-border u-rounded u-margin-bottom-md" [ngClass]="currentTheme">
+<mat-card class="profile-card data-section u-padding-md u-margin-bottom-md" [ngClass]="currentTheme">
   <mat-toolbar class="profile-toolbar">
     <!-- Profile Name Display (Clickable to Edit) / Input Field -->
     <div class="toolbar-section profile-name-container">
@@ -288,4 +288,4 @@
       </mat-tab>
     </mat-tab-group>
   </mat-card-content>
-</div>
+</mat-card>

--- a/src/app/styles/shared-components.scss
+++ b/src/app/styles/shared-components.scss
@@ -223,6 +223,20 @@
   // text-transform: uppercase;
 }
 
+// Generic card container styling for profile components
+@mixin profile-card-base {
+  background-color: var(--color-background-panel);
+  border: 1px solid var(--color-border-panel);
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--shadow-subtle);
+  margin-bottom: var(--spacing-lg);
+  transition: box-shadow 0.3s ease-in-out;
+
+  &:hover {
+    box-shadow: var(--shadow-medium);
+  }
+}
+
 // Apply the styles directly in the global stylesheet
 .section-title-font {
   @include section-title;
@@ -246,6 +260,10 @@
   .profile-actions .icon-button {
     @include profile-actions;
   }
+}
+
+.profile-card {
+  @include profile-card-base;
 }
 
 // Optional: define these classes if needed


### PR DESCRIPTION
## Summary
- use single `profile-card` class across attacker and defender components
- define reusable mixin for card styling
- switch defender profile container to `<mat-card>`

## Testing
- `npm run lint` *(fails: parser not supported)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684027d4fba48328a33937275fa9b1a6