### PR TITLE
Switch to Material Symbols icon set

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive mathhammer calculator for Warhammer 40,000 designed to help play
 - **Multiple Profiles**: Support for multiple attacker and defender profiles
 - **Modern UI**: Clean, responsive Angular Material interface
 - **macOS-inspired Typography**: Uses the San Francisco font with a `-apple-system` fallback for a consistent look across browsers
+- **Unified Icons**: All icons use Google's Material Symbols Outlined set for a consistent line-style appearance
 
 ## Development
 

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
 </head>
 <body class="mat-typography">
   <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,6 +8,13 @@ $mat-theme-ignore-duplication-warnings: true; // Keep for now, aim to remove if 
 @use './app/styles/utilities.scss' as utilities;
 @use './app/styles/shared-components.scss' as shared;
 
+// Use Material Symbols Outlined for all mat-icon elements
+.mat-icon,
+mat-icon {
+  font-family: 'Material Symbols Outlined';
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
 // Include the core styles for Angular Material only once.
 // This renders all common structural styles.
 @include mat.core();


### PR DESCRIPTION
## Summary
- use Material Symbols Outlined across the app
- document new icon set in README

## Testing
- `npm run lint` *(fails: numerous lint errors)*
- `npm test` *(fails: no Chrome available)*

------
https://chatgpt.com/codex/tasks/task_e_684027da17688328b8b7a4358657c37f