### PR TITLE
Improve responsive layout for mobile and desktop

### DIFF
--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -27,3 +27,21 @@
 mat-form-field {
   min-width: 150px;
 }
+
+@media (max-width: 600px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-sm);
+  }
+
+  .theme-controls {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
+}

--- a/src/app/components/results/results.component.scss
+++ b/src/app/components/results/results.component.scss
@@ -19,6 +19,18 @@
     margin-top: 1.5rem; // Consistent with codigo.html
 }
 
+.results-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-md);
+}
+
+@media (max-width: 600px) {
+    .results-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 // The HTML uses inline styles for the second .final-damage-container and its .final-damage-value.
 // If preferred, these could be moved to classes:
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1099,6 +1099,16 @@ body.theme-imperium-light {
     justify-content: center; align-items: center; gap: 1rem;
     margin: 2rem auto 1.5rem auto; padding: 0 1rem; max-width: 600px;
 }
+
+@media (min-width: 600px) {
+    .action-buttons-container {
+        flex-direction: row;
+    }
+
+    .button-cogitator {
+        width: auto;
+    }
+}
 .button-cogitator {
     font-family: var(--font-gothic);
     color: var(--color-text-header-main);


### PR DESCRIPTION
## Summary
- add mobile layout styles for header
- update results grid to use responsive columns
- tweak action buttons container for larger screens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402a5bbb888328aa34f4f6cd37fa2e