### PR TITLE
Implement route and control animations

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,4 @@
 <app-header></app-header>
-<router-outlet></router-outlet>
+<main [@routeAnimations]="prepareRoute(outlet)">
+  <router-outlet #outlet="outlet"></router-outlet>
+</main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import {
+  trigger,
+  transition,
+  style,
+  animate,
+} from '@angular/animations';
 import { CommonModule } from '@angular/common';
 import { HeaderComponent } from './components/header/header.component';
 
@@ -11,9 +17,21 @@ import { HeaderComponent } from './components/header/header.component';
     CommonModule,
     HeaderComponent
   ],
+  animations: [
+    trigger('routeAnimations', [
+      transition('* <=> *', [
+        style({ opacity: 0 }),
+        animate('300ms ease', style({ opacity: 1 })),
+      ]),
+    ]),
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'mathhammer-ng';
+
+  prepareRoute(outlet: RouterOutlet): string | null {
+    return outlet?.activatedRouteData?.['animation'] ?? null;
+  }
 }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,7 @@ export const routes: Routes = [
       import('./components/calculator/calculator.component').then(
         (m) => m.CalculatorComponent
       ),
+    data: { animation: 'CalculatorPage' },
   },
   {
     path: 'attacker-profile',
@@ -15,6 +16,7 @@ export const routes: Routes = [
       import('./components/attacker-profile/attacker-profile.component').then(
         (m) => m.AttackerProfileComponent
       ),
+    data: { animation: 'AttackerProfilePage' },
   },
   {
     path: 'defender-profile',
@@ -22,5 +24,6 @@ export const routes: Routes = [
       import('./components/defender-profile/defender-profile.component').then(
         (m) => m.DefenderProfileComponent
       ),
+    data: { animation: 'DefenderProfilePage' },
   },
 ];

--- a/src/app/components/theme-toggle/theme-toggle.component.scss
+++ b/src/app/components/theme-toggle/theme-toggle.component.scss
@@ -1,3 +1,11 @@
 :host {
   display: inline-block;
 }
+
+mat-slide-toggle {
+  transition: transform 0.2s ease;
+}
+
+mat-slide-toggle:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- animate route transitions with fade effect
- lightly scale theme toggle on hover

## Testing
- `npm run lint` *(fails: A config object is using the "parser" key)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402cc4844c8328a4eadab8a52d4931