### PR TITLE
Improve accessibility

### DIFF
--- a/src/app/components/calculator/calculator.component.html
+++ b/src/app/components/calculator/calculator.component.html
@@ -1,9 +1,9 @@
-<div class="cogitator-panel" [ngClass]="currentTheme$ | async">
+<div class="cogitator-panel" role="main" [ngClass]="currentTheme$ | async">
   <header class="cogitator-header">
     <h1 class="main-title">CALCULADORA DE DAÑO</h1>
     <p class="subtitle">Warhammer 40,000 - 10ª Edición</p>
   </header>
-  <form class="main-content-area">
+  <form class="main-content-area" role="form" aria-label="Calculadora de daño">
     <section class="data-section attacker-profile-section" [ngClass]="currentTheme$ | async">
       <div class="section-header u-display-flex u-justify-content-start u-align-items-center u-margin-bottom-md">
         <div class="section-title-group u-display-flex u-align-items-center u-flex-grow-1">
@@ -78,12 +78,13 @@
     </div>
   </form>
 
-  <app-results 
+  <app-results
+    aria-live="polite"
     [calculationResults]="calculationResults?.profileResults || []"
     [totalResults]="calculationResults">
   </app-results>
 
-  <footer class="cogitator-footer">
+  <footer class="cogitator-footer" role="contentinfo">
     <p>&copy; M41.999 - LA VERDAD DEL EMPERADOR ILUMINA NUESTROS DATOS - ABHORRE AL XENO, AL MUTANTE, AL HEREJE.</p>
   </footer>
 </div>

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,9 +1,12 @@
-<header class="app-header">
+<header class="app-header" role="banner">
   <h1 class="app-title">Wh40kcalculator</h1>
   <div class="theme-controls">
     <mat-form-field appearance="outline">
       <mat-label>Select Theme</mat-label>
-      <mat-select [value]="currentTheme" (selectionChange)="onThemeChange($event.value)">
+      <mat-select
+        aria-label="Selector de tema"
+        [value]="currentTheme"
+        (selectionChange)="onThemeChange($event.value)">
         <mat-option *ngFor="let theme of availableThemes" [value]="theme.value">
           {{ theme.name }}
         </mat-option>

--- a/src/app/components/results/results.component.html
+++ b/src/app/components/results/results.component.html
@@ -1,4 +1,9 @@
-<div class="results-panel" *ngIf="calculationResults.length > 0 || totalResults">
+<div
+  class="results-panel"
+  role="region"
+  aria-label="Resultados de combate"
+  aria-live="polite"
+  *ngIf="calculationResults.length > 0 || totalResults">
   <h2 class="section-title-font">PROYECCIÓN DE COMBATE</h2>
 
   <div *ngIf="calculationResults.length === 0 && !totalResults" class="results-text-font">
@@ -55,7 +60,12 @@
 
 </div>
 
-<div class="results-panel" *ngIf="calculationResults.length === 0 && !totalResults">
+<div
+  class="results-panel"
+  role="region"
+  aria-label="Resultados de combate"
+  aria-live="polite"
+  *ngIf="calculationResults.length === 0 && !totalResults">
     <h2 class="section-title-font">PROYECCIÓN DE COMBATE</h2>
     <div class="results-text-font u-font-md">
         SISTEMA INERTE. INGRESE DATOS Y ACTIVE EL COGITATOR...

--- a/src/app/components/theme-toggle/theme-toggle.component.html
+++ b/src/app/components/theme-toggle/theme-toggle.component.html
@@ -1,4 +1,5 @@
 <mat-slide-toggle
+  aria-label="Alternar modo oscuro"
   [checked]="isDarkMode"
   (change)="toggleTheme($event.checked)"
 >

--- a/src/app/themes.scss
+++ b/src/app/themes.scss
@@ -4,7 +4,7 @@
 
 .theme-imperium-dark {
   --color-primary-text: #e0dac5; // Parchment text
-  --color-secondary-text: #b0a58f; // Slightly darker parchment
+  --color-secondary-text: #c3b5a0; // Improved contrast
   --color-background-main: #1f1a15; // Very dark brown/black
   --color-background-panel: rgba(40, 35, 30, 0.95); // Dark, slightly transparent wood/metal
   --color-border-panel: #6d5f47; // Bronze/brass border
@@ -43,7 +43,7 @@
 .theme-ork-rust {
   --color-primary-text: #d1c7b7; // Dirty, off-white
   // Adjusted for WCAG 2.2 AA contrast compliance
-  --color-secondary-text: #b6aea0;
+  --color-secondary-text: #d4cbbb; // Improved contrast
   --color-background-main: #4a3b2a; // Rusty brown background
   --color-background-panel: rgba(60, 45, 30, 0.92); // Dark, rusty metal panel
   --color-border-panel: #8c5a2b; // Darker rust border
@@ -81,7 +81,7 @@
 
 .theme-necrontyr-green {
   --color-primary-text: #a2f5b4; // Necron green glow text
-  --color-secondary-text: #7bc48c;
+  --color-secondary-text: #91d5a1; // Improved contrast
   --color-background-main: #08140a; // Very dark, almost black green
   --color-background-panel: rgba(10, 40, 20, 0.93); // Dark green, slightly transparent necrodermis
   --color-border-panel: #0a5c15; // Sharp green border
@@ -120,7 +120,7 @@
 // Light Theme (redefined with CSS variables for consistency)
 .light-theme {
   --color-primary-text: #333333;
-  --color-secondary-text: #555555;
+  --color-secondary-text: #444444; // Improved contrast
   --color-background-main: #f0f0f0;
   --color-background-panel: #ffffff;
   --color-border-panel: #dcdcdc;
@@ -159,7 +159,7 @@
 // Imperium Light Theme (alternative light mode)
 .theme-imperium-light {
   --color-primary-text: #4a3a2b; // Dark parchment text
-  --color-secondary-text: #6b5a44;
+  --color-secondary-text: #514031; // Improved contrast
   --color-background-main: #faf7f2; // Warm parchment background
   --color-background-panel: #f5f0e6;
   --color-border-panel: #d0c0a0;


### PR DESCRIPTION
## Summary
- add banner role and theme selector label
- label dark mode toggle
- mark main form and results region for screen readers
- expose footer as contentinfo
- tweak theme contrast

## Testing
- `npm run lint` *(fails: 486 errors)*
- `npm test` *(fails to launch Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68402cd91de083289516f284c5814c41