### PR TITLE
Add animated Tabs component

### DIFF
--- a/src/app/components/tabs/tab.component.ts
+++ b/src/app/components/tabs/tab.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input, TemplateRef, ContentChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-tab',
+  standalone: true,
+  imports: [CommonModule],
+  template: '<ng-template><ng-content></ng-content></ng-template>'
+})
+export class TabComponent {
+  @Input() label = '';
+  @Input() active = false;
+  @ContentChild(TemplateRef, { static: true }) content!: TemplateRef<unknown>;
+}

--- a/src/app/components/tabs/tabs.component.html
+++ b/src/app/components/tabs/tabs.component.html
@@ -1,0 +1,29 @@
+<div class="tabs" role="tablist">
+  <button
+    *ngFor="let tab of tabs; let i = index"
+    class="tab-label"
+    role="tab"
+    [attr.id]="'tab-' + i"
+    [attr.aria-selected]="i === activeIndex"
+    [attr.aria-controls]="'panel-' + i"
+    (click)="selectTab(i)"
+    (keydown)="onKeydown($event, i)"
+  >
+    {{ tab.label }}
+  </button>
+  <span class="active-underline" [style.transform]="'translateX(' + activeIndex * 100 + '%)'" [style.width]="'calc(100% / ' + tabs.length + ')'" aria-hidden="true"></span>
+</div>
+
+<div class="tab-panels">
+  <ng-container *ngFor="let tab of tabs; let i = index">
+    <div
+      class="tab-panel"
+      role="tabpanel"
+      *ngIf="i === activeIndex"
+      [attr.id]="'panel-' + i"
+      [attr.aria-labelledby]="'tab-' + i"
+    >
+      <ng-container *ngTemplateOutlet="tab.content"></ng-container>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/components/tabs/tabs.component.scss
+++ b/src/app/components/tabs/tabs.component.scss
@@ -1,0 +1,42 @@
+:host {
+  display: block;
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid currentColor;
+  position: relative;
+}
+
+.tab-label {
+  flex: 1 1 auto;
+  background: none;
+  border: 0;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: center;
+}
+
+.tab-label[aria-selected='true'] {
+  font-weight: 600;
+}
+
+.tab-label:focus {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.active-underline {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background-color: currentColor;
+  transition: transform 0.3s ease;
+}
+
+.tab-panels {
+  padding-top: 1rem;
+}

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -1,0 +1,40 @@
+import { Component, AfterContentInit, ContentChildren, QueryList, HostBinding } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TabComponent } from './tab.component';
+
+@Component({
+  selector: 'app-tabs',
+  standalone: true,
+  imports: [CommonModule, TabComponent],
+  templateUrl: './tabs.component.html',
+  styleUrls: ['./tabs.component.scss']
+})
+export class TabsComponent implements AfterContentInit {
+  @ContentChildren(TabComponent) tabs!: QueryList<TabComponent>;
+  activeIndex = 0;
+
+  @HostBinding('style.--tab-count') get tabCount(): number {
+    return this.tabs?.length || 0;
+  }
+
+  ngAfterContentInit(): void {
+    const active = this.tabs.toArray().findIndex(tab => tab.active);
+    this.activeIndex = active >= 0 ? active : 0;
+  }
+
+  selectTab(index: number): void {
+    this.activeIndex = index;
+  }
+
+  onKeydown(event: KeyboardEvent, index: number): void {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      const next = index + 1 >= this.tabs.length ? 0 : index + 1;
+      this.selectTab(next);
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const prev = index === 0 ? this.tabs.length - 1 : index - 1;
+      this.selectTab(prev);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `TabsComponent` and `TabComponent`
- support keyboard and click navigation
- basic animated underline styling

## Testing
- `npm run lint` *(fails: A config object is using the "parser" key)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840379b63fc8328b167a362f4204515