### PR TITLE
Implement collapsible profile panel

### DIFF
--- a/src/app/components/attacker-profile/attacker-profile.component.html
+++ b/src/app/components/attacker-profile/attacker-profile.component.html
@@ -1,3 +1,4 @@
+<app-profile-panel>
 <mat-card class="profile-card" [ngClass]="currentTheme">
   <!-- Toolbar for Profile Actions, Name, and Attacks Display -->
   <mat-toolbar class="attacker-profile-toolbar">
@@ -748,3 +749,4 @@
     </mat-tab-group>
   </mat-card-content>
 </mat-card>
+</app-profile-panel>

--- a/src/app/components/attacker-profile/attacker-profile.component.spec.ts
+++ b/src/app/components/attacker-profile/attacker-profile.component.spec.ts
@@ -15,6 +15,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { ProfilePanelComponent } from '../profile-panel/profile-panel.component';
 
 describe('AttackerProfileComponent', () => {
   let component: AttackerProfileComponent;
@@ -40,6 +41,7 @@ describe('AttackerProfileComponent', () => {
         MatIconModule,
         MatButtonModule,
         MatTooltipModule,
+        ProfilePanelComponent,
         AttackerProfileComponent, // Importar el componente standalone
       ],
     }).compileComponents();

--- a/src/app/components/attacker-profile/attacker-profile.component.ts
+++ b/src/app/components/attacker-profile/attacker-profile.component.ts
@@ -22,6 +22,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu'; // Import MatMenuTrigger
+import { ProfilePanelComponent } from '../profile-panel/profile-panel.component';
 
 import {
   AttackerProfile,
@@ -51,6 +52,7 @@ import { Subscription } from 'rxjs'; // Import Subscription
     MatToolbarModule,
     MatTabsModule, // Add MatTabsModule here
     MatMenuModule, // Add MatMenuModule here
+    ProfilePanelComponent,
   ],
   templateUrl: './attacker-profile.component.html',
   styleUrls: ['./attacker-profile.component.scss'],

--- a/src/app/components/defender-profile/defender-profile.component.html
+++ b/src/app/components/defender-profile/defender-profile.component.html
@@ -1,3 +1,4 @@
+<app-profile-panel>
 <mat-card class="profile-card data-section u-padding-md u-margin-bottom-md" [ngClass]="currentTheme">
   <mat-toolbar class="profile-toolbar">
     <!-- Profile Name Display (Clickable to Edit) / Input Field -->
@@ -289,3 +290,4 @@
     </mat-tab-group>
   </mat-card-content>
 </mat-card>
+</app-profile-panel>

--- a/src/app/components/defender-profile/defender-profile.component.spec.ts
+++ b/src/app/components/defender-profile/defender-profile.component.spec.ts
@@ -12,6 +12,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { ProfilePanelComponent } from '../profile-panel/profile-panel.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 
@@ -35,6 +36,7 @@ describe('DefenderProfileComponent', () => {
         MatSlideToggleModule,
         MatExpansionModule,
         MatTooltipModule,
+        ProfilePanelComponent,
         DefenderProfileComponent, // Import standalone component
       ],
       providers: [

--- a/src/app/components/defender-profile/defender-profile.component.ts
+++ b/src/app/components/defender-profile/defender-profile.component.ts
@@ -23,6 +23,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatTabsModule } from '@angular/material/tabs'; // Provides tab functionality
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu'; // Menu support
 import { ThemeService } from '../../services/theme.service';
+import { ProfilePanelComponent } from '../profile-panel/profile-panel.component';
 
 @Component({
   selector: 'app-defender-profile',
@@ -42,6 +43,7 @@ import { ThemeService } from '../../services/theme.service';
     MatChipsModule,
     MatTabsModule, // Provides tab functionality
     MatMenuModule, // Menu support
+    ProfilePanelComponent,
   ],
   templateUrl: './defender-profile.component.html',
   styleUrls: ['./defender-profile.component.scss'],

--- a/src/app/components/profile-panel/profile-panel.component.html
+++ b/src/app/components/profile-panel/profile-panel.component.html
@@ -1,0 +1,3 @@
+<div class="panel-container" [class.expanded]="expanded" [class.collapsed]="!expanded">
+  <ng-content></ng-content>
+</div>

--- a/src/app/components/profile-panel/profile-panel.component.scss
+++ b/src/app/components/profile-panel/profile-panel.component.scss
@@ -1,0 +1,5 @@
+@use '../../styles/_mixins' as mixins;
+
+.panel-container {
+  @include mixins.collapsible-panel(1000px, 0.3s);
+}

--- a/src/app/components/profile-panel/profile-panel.component.spec.ts
+++ b/src/app/components/profile-panel/profile-panel.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProfilePanelComponent } from './profile-panel.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ProfilePanelComponent', () => {
+  let component: ProfilePanelComponent;
+  let fixture: ComponentFixture<ProfilePanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfilePanelComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfilePanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle expanded state', () => {
+    component.expanded = true;
+    component.toggle();
+    expect(component.expanded).toBeFalse();
+  });
+});

--- a/src/app/components/profile-panel/profile-panel.component.ts
+++ b/src/app/components/profile-panel/profile-panel.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-profile-panel',
+  standalone: true,
+  templateUrl: './profile-panel.component.html',
+  styleUrls: ['./profile-panel.component.scss'],
+})
+export class ProfilePanelComponent {
+  /** Controls whether the panel is expanded. */
+  @Input() expanded = true;
+
+  toggle(): void {
+    this.expanded = !this.expanded;
+  }
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -36,3 +36,21 @@
   from { opacity: 1; }
   to { opacity: 0; }
 }
+
+// Mixin for smooth collapsible panels
+@mixin collapsible-panel($max-height: 1000px, $duration: 0.3s) {
+  overflow: hidden;
+  transition: max-height $duration ease-in-out, opacity $duration ease-in-out, padding $duration ease-in-out;
+
+  &.collapsed {
+    max-height: 0;
+    opacity: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  &.expanded {
+    max-height: $max-height;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `ProfilePanelComponent` with expand/collapse capability
- add SCSS mixin for collapsible animations
- wrap attacker/defender profile cards with `<app-profile-panel>`
- update specs

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_6840379fb6248328aa096de557cfc3c3